### PR TITLE
fixed tests that break when there is no global.properties file

### DIFF
--- a/src/main/java/synapseawsconsolelogin/Auth.java
+++ b/src/main/java/synapseawsconsolelogin/Auth.java
@@ -299,7 +299,7 @@ public class Auth extends HttpServlet {
 		InputStream is = null;
 		try {
 			is = Auth.class.getClassLoader().getResourceAsStream("global.properties");
-			properties.load(is);
+			if (is!=null) properties.load(is);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		} finally {

--- a/src/test/java/synapseawsconsolelogin/AuthTest.java
+++ b/src/test/java/synapseawsconsolelogin/AuthTest.java
@@ -1,17 +1,17 @@
 package synapseawsconsolelogin;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class AuthTest {
 	
 	
-	@Before
-	public void setUp() {
+	@BeforeClass
+	public static void setUp() {
 		System.setProperty("TEAM_TO_ROLE_ARN_MAP","[{\"teamId\":\"123456\",\"roleArn\":\"arn:aws:iam::foo\"},{\"teamId\":\"345678\",\"roleArn\":\"arn:aws:iam::bar\"}]");
 	}
 


### PR DESCRIPTION
authored by @brucehoff
The tests failed because you don't have the parameters set
(e.g., no global.properties file).  I just updated the tests
to set test param's themselves so they will pass:

https://github.com/Sage-Bionetworks/SynapseAWSConsoleLogin/commit/ad5c0c8f3504152f9390c77b7d276c91ba42415a