### PR TITLE
[SC-64] fix duplicate url-pattern

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -8,7 +8,7 @@
     	<servlet-name>default</servlet-name>
     	<url-pattern>/</url-pattern>
 	</servlet-mapping>
-  
+
 	<servlet>
 		<servlet-name>synapseAwsConsoleLogin</servlet-name>
 		<servlet-class>synapseawsconsolelogin.Auth</servlet-class>
@@ -17,7 +17,6 @@
 	<servlet-mapping>
 		<servlet-name>synapseAwsConsoleLogin</servlet-name>
 		<url-pattern>/synapse</url-pattern>
-		<url-pattern>/</url-pattern>
 	</servlet-mapping>
 
 </web-app>


### PR DESCRIPTION
Remove duplicate url-pattern to fix this error..

SEVERE [localhost-startStop-1] org.apache.tomcat.util.descriptor.web.WebXmlParser.parseWebXml
 Parse error in application web.xml file at [file:/var/lib/tomcat8/webapps/ROOT/WEB-INF/web.xml]
 org.xml.sax.SAXParseException; systemId: file:/var/lib/tomcat8/webapps/ROOT/WEB-INF/web.xml;
 lineNumber: 21; columnNumber: 20; Error at (21, 20) : The servlets named [default] and
 [synapseAwsConsoleLogin] are both mapped to the url-pattern [/] which is not permitted
 at org.apache.tomcat.util.digester.Digester.createSAXException(Digester.java:1929)