### PR TITLE
[SC-64] disable AWS xray

### DIFF
--- a/.ebextensions/debugging.config
+++ b/.ebextensions/debugging.config
@@ -1,0 +1,4 @@
+option_settings:
+  aws:elasticbeanstalk:xray:
+    XRayEnabled: false
+


### PR DESCRIPTION
Tomcat warning on startup
WARNING [localhost-startStop-1] com.amazonaws.xray.plugins.ElasticBeanstalkPlugin.populateRuntimeContext
Unable to read Beanstalk configuration at path /var/elasticbeanstalk/xray/environment.conf

This makes sure that xray is disabled on startup.