### PR TITLE
[SC-64] add properties file

### DIFF
--- a/src/main/resources/global.properties
+++ b/src/main/resources/global.properties
@@ -1,0 +1,6 @@
+SYNAPSE_OAUTH_CLIENT_ID=100050
+TEAM_TO_ROLE_ARN_MAP=[{"teamId":"273957","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}]
+AWS_REGION=us-east-1
+SESSION_TIMEOUT_SECONDS=28800
+USER_CLAIMS=userid
+


### PR DESCRIPTION
We are moving synapse login app configs from beanstalk environment vars
to global.properties due to an issue where Beanstalk stripping quotes
from json strings when read from beanstalk env vars. Stripping quotes
makes the json invalid which causes the app to fail.

More info about the beanstalk issue here:
 https://stackoverflow.com/questions/26553553/json-stored-in-aws-eb-environment-variables-is-retrieved-without-quote