### PR TITLE
Fix build: remove pyyaml install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ install:
   - unzip -j -n /tmp/infra-utils.zip -x "infra-utils-master/.gitignore" "infra-utils-master/LICENSE" "infra-utils-master/*.md" "infra-utils-master/aws/*"
   - ./setup_aws_cli.sh || travis_terminate 1
   - pip install --upgrade pre-commit awsebcli
-  - pip install pyYaml==5.2
 stages:
   - name: test
   - name: deploy


### PR DESCRIPTION
We needed to pin PyYaml previously because awscli and awsebcli
had conflicting PyYaml version requirements.  It looks like they
have fixed their issues and now we no longer need to pin.